### PR TITLE
KSPHPDDM --with-cuda --with-scalar-type=complex

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,9 +119,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -yq `echo $PKGS`
           mkdir -p ~/.cache
           for pkg in `echo $PKGS`; do
-              for dep in $pkg; do
-                  dpkg -L $dep | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/.cache/
-              done
+            for dep in $pkg; do
+              dpkg -L $dep | while IFS= read -r f; do if test -f $f; then echo $f; fi; done | xargs cp --parents --target-directory ~/.cache/
+            done
           done
           pip install --user mpi4py numpy==2.1.3 scipy
           rm -rf ~/.cache/pip
@@ -315,12 +315,14 @@ jobs:
     steps:
     - name: Fetch PETSc and data files
       run: |
-        rm -rf petsc ${{ github.event.repository.name }} petsc_datafiles.tar.xz coverage_nvcc.info
+        rm -rf petsc ${{ github.event.repository.name }} petsc_datafiles.tar.xz coverage_nvcc.info coverage_nvcc_complex.info
         git clone --depth=1 -b ${{ needs.variables.outputs.petsc-branch }} https://gitlab.com/petsc/petsc.git
-        git clone --depth=1 -b ${{ needs.variables.outputs.hpddm-branch }} git@github.com:${{ github.repository }}
+        git clone --depth=1 -b ${{ needs.variables.outputs.hpddm-branch }} git@github.com:${{ github.event.pull_request.head.repo.full_name || github.repository }}
         wget -nv https://joliv.et/petsc_datafiles.tar.xz && tar xJf petsc_datafiles.tar.xz || exit 1
       if: matrix.runs_on != 'ubuntu-24.04'
     - name: Build and test with PETSc and SLEPc
+      env:
+        HOSTNAME: ${{ secrets.HOSTNAME }}
       run: |
         cd petsc
         export COVERAGE_FLAGS="-fprofile-arcs -ftest-coverage"
@@ -334,34 +336,50 @@ jobs:
         sed -i -e 's=starttime: pre-clean $(libpetscall)=starttime: pre-clean=;s=$(testexe.c) $(testexe.cu) : $(TESTDIR)/% : $(TESTDIR)/%.o $$^ $(libpetscall)=$(testexe.c) $(testexe.cu) : $(TESTDIR)/% : $(TESTDIR)/%.o $$^=;s=$(call quiet,CLINKER) $(EXEFLAGS) -o $@ $^ $(PETSC_TEST_LIB=$(call quiet,CLINKER) $(EXEFLAGS) -o $@ $^ $(libpetscall) $(PETSC_TEST_LIB=g' gmakefile.test
         echo ::add-mask::${{ secrets.HOSTNAME }}
         echo ::add-mask::${{ secrets.LOGIN }}
-        echo ::add-mask::${{ secrets.GROUP }}
         export INCS="-I`pwd`/../${REPOSITORY_NAME}/include"
-        ./configure --with-strict-petscerrorcode --with-mpi-dir=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt \
-                    --with-hwloc-dir=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt \
-                    --with-blaslapack-lib=[/local/${{ secrets.LOGIN }}/lib/libmkl_core.so,/local/${{ secrets.LOGIN }}/lib/libmkl_intel_lp64.so,/local/${{ secrets.LOGIN }}/lib/libmkl_sequential.so] \
-                    --with-blaslapack-include=/local/${{ secrets.LOGIN }}/include --with-mkl_pardiso \
-                    --with-c2html=0 --with-hipc=0 --with-x=0 --with-fc=0 --download-slepc \
-                    --download-hpddm=../${{ github.event.repository.name }} --download-hpddm-commit=HEAD \
-                    --with-cuda --download-thrust 'CXXPPFLAGS=${PETSC_CXXPPFLAGS}' 'CUDAFLAGS+=--compiler-options -Wall,-Wextra,-Werror,-Wno-psabi,-Wno-deprecated-declarations ${INCS}'
-        [ -z "`diff -rq ${PETSC_ARCH}/include ../${REPOSITORY_NAME}/include | grep -v Only`" ] || exit 1
-        rm -rf ${PETSC_ARCH}/include/HPDDM* && sed -i -e 's@petsc/arch-ci/externalpackages/git.hpddm@${REPOSITORY_NAME}@g' -e 's@hpddm_petsc.cpp@hpddm_petsc.cpp ${COVERAGE_FLAGS} -I`pwd`/../`echo ${REPOSITORY_NAME}`/include@' ${PETSC_ARCH}/lib/petsc/conf/petscrules
-        rm -rf /local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/include/HPDDM*
-        make all "CXX=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicxx ${COVERAGE_FLAGS} ${INCS}" "CLINKER=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicc ${COVERAGE_FLAGS} -fopenmp" "CUDA_CXXFLAGS=${COVERAGE_FLAGS} ${INCS} -fvisibility=hidden"
-        cat ${PETSC_ARCH}/lib/petsc/conf/hpddm*.log
-        export LD_PRELOAD="/software/gcc/14/lib64/libstdc++.so.6 `pwd`/arch-ci/lib/libpetsc.so `pwd`/arch-ci/lib/libslepc.so"
-        export LD_LIBRARY_PATH=/software/gcc/14/lib:/software/gcc/14/lib64:/software/cuda/13.1/lib64
-        make check
-        make -f gmakefile test 'query=requires' 'queryval=*hpddm*' "CC=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicc ${COVERAGE_FLAGS}" "CLINKER=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicc ${COVERAGE_FLAGS}" EXTRA_OPTIONS='-malloc_dump' check-test-errors || exit 1
-        config/report_tests.py -t 5 -s
-        cd ../${REPOSITORY_NAME}
         PERL5LIB="${HOME}/perl5/lib/perl5${PERL5LIB:+:${PERL5LIB}}"; export PERL5LIB;
-        ~/lcov-2.1/bin/lcov --ignore-errors inconsistent,usage --directory . --directory ../petsc/arch-ci/lib --exclude '/software/*' --exclude '*/petsc/include/*' --exclude '/tmp/*' --capture --output-file ../coverage_nvcc.info
-      if: matrix.runs_on != 'ubuntu-24.04'
+        for TYPE in complex real
+        do
+          unset EXTERNALPACKAGES
+          unset COVERAGE_EXTENSION
+          if [ "$TYPE" = "complex" ]; then
+            export EXTERNALPACKAGES="--with-scalar-type=complex --with-precision=single" COVERAGE_EXTENSION="_complex"
+          fi
+          ./configure --with-strict-petscerrorcode --with-mpi-dir=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt \
+                      --with-hwloc-dir=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt \
+                      --with-blaslapack-lib=[/local/${{ secrets.LOGIN }}/lib/libmkl_core.so,/local/${{ secrets.LOGIN }}/lib/libmkl_intel_lp64.so,/local/${{ secrets.LOGIN }}/lib/libmkl_sequential.so] \
+                      --with-blaslapack-include=/local/${{ secrets.LOGIN }}/include --with-mkl_pardiso \
+                      --with-c2html=0 --with-hipc=0 --with-x=0 --with-fc=0 --download-slepc \
+                      --download-hpddm=../${{ github.event.repository.name }} --download-hpddm-commit=HEAD \
+                      --with-cuda --download-thrust 'CXXPPFLAGS=${PETSC_CXXPPFLAGS}' 'CUDAFLAGS+=--compiler-options -Wall,-Wextra,-Werror,-Wno-psabi,-Wno-deprecated-declarations ${INCS}' \
+                      ${EXTERNALPACKAGES}
+          [ -z "`diff -rq ${PETSC_ARCH}/include ../${REPOSITORY_NAME}/include | grep -v Only`" ] || exit 1
+          rm -rf ${PETSC_ARCH}/include/HPDDM* && sed -i -e 's@petsc/arch-ci/externalpackages/git.hpddm@${REPOSITORY_NAME}@g' -e 's@hpddm_petsc.cpp@hpddm_petsc.cpp ${COVERAGE_FLAGS} -I`pwd`/../`echo ${REPOSITORY_NAME}`/include@' ${PETSC_ARCH}/lib/petsc/conf/petscrules
+          rm -rf /local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/include/HPDDM*
+          make all "CXX=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicxx ${COVERAGE_FLAGS} ${INCS}" "CLINKER=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicc ${COVERAGE_FLAGS} -fopenmp" "CUDA_CXXFLAGS=${COVERAGE_FLAGS} ${INCS} -fvisibility=hidden"
+          cat ${PETSC_ARCH}/lib/petsc/conf/hpddm*.log
+          export LD_PRELOAD="/software/gcc/14/lib64/libstdc++.so.6 `pwd`/arch-ci/lib/libpetsc.so `pwd`/arch-ci/lib/libslepc.so"
+          export LD_LIBRARY_PATH=/software/gcc/14/lib:/software/gcc/14/lib64:/software/cuda/13.1/lib64
+          make check
+          make -f gmakefile test 'query=requires' 'queryval=*hpddm*' "CC=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicc ${COVERAGE_FLAGS}" "CLINKER=/local/${{ secrets.LOGIN }}/petsc/arch-linux-c-opt/bin/mpicc ${COVERAGE_FLAGS}" EXTRA_OPTIONS='-malloc_dump' check-test-errors || exit 1
+          config/report_tests.py -t 5 -s
+          unset LD_PRELOAD
+          unset LD_LIBRARY_PATH
+          cd ../${REPOSITORY_NAME}
+          ~/lcov-2.1/bin/lcov --ignore-errors inconsistent,usage --directory . --directory ../petsc/arch-ci/lib --exclude '/software/*' --exclude '*/petsc/include/*' --exclude '/tmp/*' --capture --output-file ../coverage_nvcc${COVERAGE_EXTENSION}.info
+          find .. -name '*.gcda' -delete
+          cd -
+        done
+      if: matrix.runs_on != 'ubuntu-24.04' && env.HOSTNAME != ''
     - uses: actions/upload-artifact@v7
+      env:
+        HOSTNAME: ${{ secrets.HOSTNAME }}
       with:
         name: artifact-self-hosted
-        path: coverage_nvcc.info
-      if: matrix.runs_on != 'ubuntu-24.04'
+        path: |
+          coverage_nvcc.info
+          coverage_nvcc_complex.info
+      if: matrix.runs_on != 'ubuntu-24.04' && env.HOSTNAME != ''
   post-main:
     runs-on: ubuntu-24.04
     if: ${{ failure() }}

--- a/include/HPDDM.hpp
+++ b/include/HPDDM.hpp
@@ -240,6 +240,12 @@ template <class T>
 struct underlying_type_spec<std::complex<T>> {
   typedef T type;
 };
+  #if defined(PETSC_HAVE_CUDA) && (defined(__NVCC__) || defined(__CUDACC__))
+template <class T>
+struct underlying_type_spec<thrust::complex<T>> {
+  typedef T type;
+};
+  #endif
 template <class T>
 using underlying_type = typename underlying_type_spec<T>::type;
 template <class T>
@@ -281,7 +287,15 @@ inline underlying_type<T> imag(const T &v)
 namespace HPDDM
 {
 template <class T>
-using downscaled_type = typename std::conditional<std::is_same<underlying_type<T>, T>::value, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, double>::value, float, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, float>::value, __fp16, T>::type>::type, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, std::complex<double>>::value, std::complex<float>, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, std::complex<float>>::value, std::complex<__fp16>, T>::type>::type>::type;
+using downscaled_type = typename std::conditional<std::is_same<underlying_type<T>, T>::value, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, double>::value, float, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, float>::value, __fp16, T>::type>::type,
+                                                  typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, std::complex<double>>::value, std::complex<float>,
+                                                                            typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, std::complex<float>>::value, std::complex<__fp16>,
+    #if defined(PETSC_HAVE_CUDA) && (defined(__NVCC__) || defined(__CUDACC__))
+                                                                                                      typename std::conditional<std::is_same<T, thrust::complex<double>>::value, thrust::complex<float>, T>::type
+    #else
+                                                                                                      T
+    #endif
+                                                                                                      >::type>::type>::type;
 } // namespace HPDDM
     #if !defined(PETSC_HAVE_REAL___FLOAT128) || defined(PETSC_SKIP_REAL___FLOAT128)
       #include "HPDDM_specifications.hpp"
@@ -290,14 +304,27 @@ using downscaled_type = typename std::conditional<std::is_same<underlying_type<T
 namespace HPDDM
 {
 template <class T>
-using downscaled_type = typename std::conditional<std::is_same<underlying_type<T>, T>::value, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, double>::value, float, T>::type, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, std::complex<double>>::value, std::complex<float>, T>::type>::type;
+using downscaled_type = typename std::conditional<std::is_same<underlying_type<T>, T>::value, typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, double>::value, float, T>::type,
+                                                  typename std::conditional<HPDDM_MIXED_PRECISION && std::is_same<T, std::complex<double>>::value, std::complex<float>,
+    #if defined(PETSC_HAVE_CUDA) && (defined(__NVCC__) || defined(__CUDACC__))
+                                                                            typename std::conditional<std::is_same<T, thrust::complex<double>>::value, thrust::complex<float>, T>::type
+    #else
+                                                                            T
+    #endif
+                                                                            >::type>::type;
 } // namespace HPDDM
   #endif
   #if !defined(PETSC_HAVE_REAL___FLOAT128) || defined(PETSC_SKIP_REAL___FLOAT128) || defined(__NVCC__) || defined(__CUDACC__)
 namespace HPDDM
 {
 template <class T>
-using upscaled_type = typename std::conditional<std::is_same<underlying_type<T>, T>::value, double, std::complex<double>>::type;
+using upscaled_type = typename std::conditional<std::is_same<underlying_type<T>, T>::value, double,
+    #if defined(PETSC_HAVE_CUDA) && (defined(__NVCC__) || defined(__CUDACC__))
+                                                typename std::conditional<std::is_same<T, std::complex<underlying_type<T>>>::value, std::complex<double>, thrust::complex<double>>::type
+    #else
+                                                std::complex<double>
+    #endif
+                                                >::type;
 template <class T>
 inline T sqrt(const T &v)
 {
@@ -323,6 +350,14 @@ inline OutputIt copy_n(InputIt in, Size n, OutputIt out)
 {
   return std::copy_n(in, n, out);
 }
+    #if defined(PETSC_HAVE_CUDA) && (defined(__NVCC__) || defined(__CUDACC__))
+template <template <class> class InputType, class T, template <class> class OutputType, class U, class Size>
+inline OutputType<U> *copy_n(const InputType<T> *in, Size n, OutputType<U> *out)
+{
+  for (Size i = 0; i < n; ++i) out[i] = OutputType<U>(in[i].real(), in[i].imag());
+  return out + n;
+}
+    #endif
 } // namespace HPDDM
   #else
     #include <quadmath.h>

--- a/interface/petsc/ksp/cuda/hpddm.cu
+++ b/interface/petsc/ksp/cuda/hpddm.cu
@@ -28,7 +28,13 @@ PetscErrorCode KSPSolve_HPDDM_CUDA_Private(KSP_HPDDM *data, const PetscScalar *b
     thrust::copy_n(thrust::cuda::par.on(PetscDefaultCudaStream), db, N, dptr[0]);
     thrust::copy_n(thrust::cuda::par.on(PetscDefaultCudaStream), dx, N, dptr[1]);
     PetscCallCUDA(cudaMemcpy(host_ptr, ptr, 2 * N * sizeof(K), cudaMemcpyDeviceToHost));
+#if PetscDefined(USE_COMPLEX)
+    /* reinterpret thrust::complex<> as std::complex<> so that HPDDM deduces a type with BLAS/LAPACK and MPI support */
+    std::complex<HPDDM::underlying_type<K>> *const hb = reinterpret_cast<std::complex<HPDDM::underlying_type<K>> *>(host_ptr);
+    PetscCall(HPDDM::IterativeMethod::solve(*data->op, hb, hb + N, n, comm));
+#else
     PetscCall(HPDDM::IterativeMethod::solve(*data->op, host_ptr, host_ptr + N, n, comm));
+#endif
     PetscCallCUDA(cudaMemcpy(ptr + N, host_ptr + N, N * sizeof(K), cudaMemcpyHostToDevice));
     thrust::copy_n(thrust::cuda::par.on(PetscDefaultCudaStream), dptr[1], N, dx);
     PetscCallCUDA(cudaFree(ptr));
@@ -41,7 +47,12 @@ PetscErrorCode KSPSolve_HPDDM_CUDA_Private(KSP_HPDDM *data, const PetscScalar *b
     PetscCall(PetscMalloc1(2 * N, &host_ptr));
     PetscCallCUDA(cudaMemcpy(host_ptr, b, N * sizeof(PetscScalar), cudaMemcpyDeviceToHost));
     PetscCallCUDA(cudaMemcpy(host_ptr + N, x, N * sizeof(PetscScalar), cudaMemcpyDeviceToHost));
+#if PetscDefined(USE_COMPLEX)
+    std::complex<PetscReal> *const hb = reinterpret_cast<std::complex<PetscReal> *>(host_ptr);
+    PetscCall(HPDDM::IterativeMethod::solve(*data->op, hb, hb + N, n, comm));
+#else
     PetscCall(HPDDM::IterativeMethod::solve(*data->op, host_ptr, host_ptr + N, n, comm));
+#endif
     PetscCallCUDA(cudaMemcpy(x, host_ptr + N, N * sizeof(PetscScalar), cudaMemcpyHostToDevice));
     PetscCall(PetscFree(host_ptr));
     PetscCall(PetscLogGpuToCpu(2 * N * sizeof(PetscScalar)));


### PR DESCRIPTION
Building PETSc with `--download-hpddm` and `--with-cuda` does not work, because `PetscScalar` is a `thrust::complex` but HPDDM assumes it's `std::complex`. This messes up many templates (where pattern matching assumes `std`) and leads to a failed build, unlike with real arithmetic.

This PR adds various traits and specializations with `thrust::complex`, and sometimes uses `reinterpret_casts()` to get back on the `std::complex` path. I'm still cleaning it up as I may have been overly defensive at some places.

Current states builds successfully (with `make check`) on my laptop with real/complex + single/double precision. Haven't tested in actual cases yet.

I'm not 100% sure I respect previous design choices. Am I correct in my reading of the code that its current state is 1) CUDA tested only in real 2) if a `KSPHPDDM` is used with a CUDA matrix, the `MatMult()` and `PCApply()` are performed in device and then the HPDDM part (Arnoldi, etc.) moved back to CPU?

Further tests coming in the future!

PS: some of my changes are possibly redundant with each other, I'll clean those up if it's true.

PPS: I have no clue about interactions with half precision or quad precision.